### PR TITLE
[Refactor] 오류 분석 로직과 퀴즈 생성 로직 분리

### DIFF
--- a/app/api/quiz_router.py
+++ b/app/api/quiz_router.py
@@ -21,7 +21,7 @@ async def generate_quiz(request: QuizRequest):
         raise HTTPException(status_code=400, detail=f"유효하지 않은 레벨입니다: {request.level}")
 
     try:
-        errors = await _reading_service.get_errors(request.book_id)
+        errors = await _reading_service.get_errors(request.child_id, request.book_id)
 
         if request.level in PHONEME_LEVELS:
             pattern, word = _reading_service.get_top_phoneme_error(errors)

--- a/app/api/quiz_router.py
+++ b/app/api/quiz_router.py
@@ -1,17 +1,15 @@
 from fastapi import APIRouter, HTTPException
-from app.schemas.quiz_schema import QuizRequest, QuizResponse, PhonemeErrorDetail, JosaErrorDetail
-from app.services.phoneme_analyzer import PhonemeAnalyzerService
-from app.services.josa_analyzer import JosaAnalyzerService
+from app.schemas.quiz_schema import QuizRequest, QuizResponse
 from app.services.quiz_generator import QuizGeneratorService
+from app.services.reading_service import get_reading_service
 
 router = APIRouter(
     prefix="/ai/quiz",
     tags=["Quiz Generator"]
 )
 
-_phoneme_analyzer = PhonemeAnalyzerService()
-_josa_analyzer    = JosaAnalyzerService()
 _quiz_generator   = QuizGeneratorService()
+_reading_service = get_reading_service()
 
 PHONEME_LEVELS = {"L1", "L2", "L3"}
 JOSA_LEVELS    = {"L4", "L5", "L6"}
@@ -21,23 +19,21 @@ async def generate_quiz(request: QuizRequest):
     # 레벨 검증
     if request.level not in PHONEME_LEVELS | JOSA_LEVELS:
         raise HTTPException(status_code=400, detail=f"유효하지 않은 레벨입니다: {request.level}")
-    
-    try:
-        original_text = " ".join(request.original_text)
-        stt_text = " ".join(request.stt_text)
 
-        reports, words = _phoneme_analyzer.analyze(original_text, stt_text)
-        events = _josa_analyzer.analyze(original_text, stt_text)
+    try:
+        errors = await _reading_service.get_errors(request.book_id)
 
         if request.level in PHONEME_LEVELS:
-            pattern, target_word, count = _phoneme_analyzer.get_top_error(reports, words)
-            quiz_items = await _quiz_generator.generate_quiz_words(target_word, pattern)
+            pattern, word = _reading_service.get_top_phoneme_error(errors)
+            quiz_items = await _quiz_generator.generate_quiz_words(word, pattern)
         else:
-            top_event = _josa_analyzer.get_top_event(events)
-            quiz_items = await _quiz_generator.generate_josa_quiz(top_event)
+            event = _reading_service.get_top_josa_error(errors)
+            quiz_items = await _quiz_generator.generate_josa_quiz(event)
+
         return QuizResponse(quiz_items=quiz_items)
-        
+
     except ValueError as e:
-        raise HTTPException(status_code=400, detail=str(e))
+        # 오류 패턴이 없는 경우 (아이가 완벽하게 읽은 구간)
+        raise HTTPException(status_code=404, detail=str(e))
     except Exception as e:
         raise HTTPException(status_code=500, detail=f"퀴즈 생성 중 오류 발생: {str(e)}")

--- a/app/schemas/quiz_schema.py
+++ b/app/schemas/quiz_schema.py
@@ -1,22 +1,10 @@
 from pydantic import BaseModel, Field
-from typing import List, Optional, Union
+from typing import List
 
 # 음운 퀴즈
 class QuizRequest(BaseModel):
-    original_text: List[str] = Field(..., description="동화 원문 텍스트")
-    stt_text: List[str] = Field(..., description="아이가 낭독한 STT 결과 텍스트")
-    level: str = Field(..., description="아동의 현재 읽기 레벨(L1-L6)")
-
-class PhonemeErrorDetail(BaseModel):
-    error_pattern: str = Field(..., description="가장 빈번한 오류 패턴")
-    target_word: str = Field(..., description="오류가 발생한 원래 단어")
-    error_count: int = Field(..., description="해당 오류 패턴의 발생 횟수")
-
-class JosaErrorDetail(BaseModel):
-    kind: str = Field(..., description="조사 오류 종류: DELETE, SUBSTITUTION | INSERTION")
-    stem: str = Field(..., description="조사 오류가 발생한 체언")
-    target_josa: Optional[str] = Field(None, description="원문 조사")
-    stt_josa: Optional[str] = Field(None, description="아이가 읽은 조사")
+    book_id: str = Field(..., description="동화 ID")
+    level: str = Field(..., description="아동의 현재 읽기 레벨(L1~L6)")
 
 class QuizResponse(BaseModel):
     quiz_items: List[str] = Field(..., description="단어 4개(L1~L3) 또는 문장 4개(L4~L6)")

--- a/app/schemas/quiz_schema.py
+++ b/app/schemas/quiz_schema.py
@@ -3,7 +3,8 @@ from typing import List
 
 # 음운 퀴즈
 class QuizRequest(BaseModel):
-    book_id: str = Field(..., description="동화 ID")
+    child_id: int = Field(..., description="아동 ID")
+    book_id: int = Field(..., description="동화 ID")
     level: str = Field(..., description="아동의 현재 읽기 레벨(L1~L6)")
 
 class QuizResponse(BaseModel):


### PR DESCRIPTION
## 🐣 작업 개요
> 구현한 기능을 요약하여 정리합니다.
- 기존에는 퀴즈 생성 요청 시 음성 오류를 분석하고 그 다음 퀴즈 생성을 진행하였으나 현재는 낭독 음성 STT와 동시에 오류 분석을 진행하도록 수정하였습니다.
- 퀴즈 생성 로직에서는 Redis에 있는 음성 오류를 가져와서 퀴즈를 생성하는 기능만 동작하도록 하였습니다.

## 📍 변경 사항
Update: quiz_schema, quiz_router

## 🚀 사용 방법
동화 낭독 진행 후 `/ai/quiz/generate`로 아동 Id, 동화 id, 아동 레벨을 입력하면 다음과 같이 퀴즈가 생성됩니다.
<img width="315" height="576" alt="스크린샷 2026-05-10 오후 3 45 13" src="https://github.com/user-attachments/assets/313429f1-3361-476b-8c7b-3c2e0810ae49" />


## ✨ 관련 이슈
- closes #24 

## 🔧 변경 유형
* [ ] Bug Fix (fix)
* [ ] New Features (feat)
* [ ] Test (test)
* [ ] Document modification (docs)
* [x] Refactoring (refactor)
* [ ] Styling (style)
* [ ] ETC, No production code change (chore)
* [ ] Build task and Dependency management (build)
---